### PR TITLE
Refine SSR stream import usage

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,7 +1,7 @@
 import type { AppLoadContext, EntryContext } from '@remix-run/cloudflare';
 import { RemixServer } from '@remix-run/react';
 import { isbot } from 'isbot';
-import { renderToReadableStream } from 'react-dom/server';
+import ReactDOMServer from 'react-dom/server';
 import { renderHeadToString } from 'remix-island';
 import { Head } from './root';
 import { themeStore } from '~/lib/stores/theme';
@@ -13,13 +13,19 @@ export default async function handleRequest(
   remixContext: EntryContext,
   _loadContext: AppLoadContext,
 ) {
-  const readable = await renderToReadableStream(<RemixServer context={remixContext} url={request.url} />, {
-    signal: request.signal,
-    onError(error: unknown) {
-      console.error(error);
-      responseStatusCode = 500;
+  const { renderToReadableStream } =
+    ReactDOMServer as typeof import('react-dom/server');
+
+  const readable = await renderToReadableStream(
+    <RemixServer context={remixContext} url={request.url} />,
+    {
+      signal: request.signal,
+      onError(error: unknown) {
+        console.error(error);
+        responseStatusCode = 500;
+      },
     },
-  });
+  );
 
   const body = new ReadableStream({
     start(controller) {


### PR DESCRIPTION
## Summary
- destructure `renderToReadableStream` from the default React DOM server import to satisfy the Vite SSR expectations while keeping typed access

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d91d5dec688329af1a2cc53d6e7bbc