### PR TITLE
Handle SSR render stream fallback resolution

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,7 +1,8 @@
 import type { AppLoadContext, EntryContext } from '@remix-run/cloudflare';
 import { RemixServer } from '@remix-run/react';
 import { isbot } from 'isbot';
-import { renderToReadableStream } from 'react-dom/server';
+import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServerBrowser from 'react-dom/server.browser';
 import { renderHeadToString } from 'remix-island';
 import { Head } from './root';
 import { themeStore } from '~/lib/stores/theme';
@@ -13,13 +14,25 @@ export default async function handleRequest(
   remixContext: EntryContext,
   _loadContext: AppLoadContext,
 ) {
-  const readable = await renderToReadableStream(<RemixServer context={remixContext} url={request.url} />, {
-    signal: request.signal,
-    onError(error: unknown) {
-      console.error(error);
-      responseStatusCode = 500;
+  const serverExports = ReactDOMServer as typeof import('react-dom/server');
+  const browserServerExports =
+    ReactDOMServerBrowser as typeof import('react-dom/server.browser');
+
+  const renderToReadableStream =
+    typeof serverExports.renderToReadableStream === 'function'
+      ? serverExports.renderToReadableStream
+      : browserServerExports.renderToReadableStream;
+
+  const readable = await renderToReadableStream(
+    <RemixServer context={remixContext} url={request.url} />,
+    {
+      signal: request.signal,
+      onError(error: unknown) {
+        console.error(error);
+        responseStatusCode = 500;
+      },
     },
-  });
+  );
 
   const body = new ReadableStream({
     start(controller) {


### PR DESCRIPTION
## Summary
- add a React DOM server.browser fallback so `renderToReadableStream` is always defined during SSR
- keep the Remix server entry streaming pipeline unchanged beyond the import resolution fix

## Testing
- pnpm run test

------
https://chatgpt.com/codex/tasks/task_e_68d91d5dec688329af1a2cc53d6e7bbc