### PR TITLE
Fix hydration mismatch for Remix root markup

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -41,7 +41,7 @@ export default async function handleRequest(
       controller.enqueue(
         new Uint8Array(
           new TextEncoder().encode(
-            `<!DOCTYPE html><html lang="en" data-theme="${themeStore.value}"><head>${head}</head><body><div id="root" class="w-full h-full">`,
+            `<!DOCTYPE html><html lang="en" data-theme="${themeStore.value}"><head>${head}</head><body class="min-h-dvh bg-neutral-950 text-white antialiased"><div id="root" class="w-full h-full">`,
           ),
         ),
       );

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -17,15 +17,10 @@ export function Head() {
 
 export default function App() {
   return (
-    <html lang="en">
-      <head>
-        <Head />
-      </head>
-      <body className="min-h-dvh bg-neutral-950 text-white antialiased">
-        <Outlet />
-        <ScrollRestoration />
-        <Scripts />
-      </body>
-    </html>
+    <>
+      <Outlet />
+      <ScrollRestoration />
+      <Scripts />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- stop rendering the `<html>` and `<body>` elements inside `app/root.tsx` so the Remix app hydrates the same markup the server streams
- move the body styling to the server-rendered shell so the page retains its look without duplicating structural tags

## Testing
- pnpm lint *(fails: repository has pre-existing lint and prettier violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d93aea94f88329a52b5c1c62db1828