### PR TITLE
Align Remix server shell with client markup

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -41,7 +41,7 @@ export default async function handleRequest(
       controller.enqueue(
         new Uint8Array(
           new TextEncoder().encode(
-            `<!DOCTYPE html><html lang="en" data-theme="${themeStore.value}"><head>${head}</head><body><div id="root" class="w-full h-full">`,
+            `<!DOCTYPE html><html lang="en" data-theme="${themeStore.value}"><head>${head}</head><body class="min-h-dvh bg-neutral-950 text-white antialiased"><div id="root" class="w-full h-full">`,
           ),
         ),
       );

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,9 +1,25 @@
 // app/root.tsx
+import type { LinksFunction } from "@remix-run/cloudflare";
 import { Meta, Links, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
 
 // Side-effect CSS imports (keep these; no ?url)
 import "@unocss/reset/tailwind.css";
 import "virtual:uno.css";
+
+import { kTheme } from "~/lib/stores/theme";
+
+const themeInitScript = `(() => {
+  try {
+    const storedTheme = localStorage.getItem(${JSON.stringify(kTheme)});
+    if (storedTheme) {
+      document.documentElement.setAttribute('data-theme', storedTheme);
+    }
+  } catch {}
+})();`;
+
+export const links: LinksFunction = () => [
+  { rel: "icon", href: "/favicon.svg", type: "image/svg+xml" },
+];
 
 // 👇 This is what entry.server.tsx expects to exist
 export function Head() {
@@ -11,21 +27,17 @@ export function Head() {
     <>
       <Meta />
       <Links />
+      <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
     </>
   );
 }
 
 export default function App() {
   return (
-    <html lang="en">
-      <head>
-        <Head />
-      </head>
-      <body className="min-h-dvh bg-neutral-950 text-white antialiased">
-        <Outlet />
-        <ScrollRestoration />
-        <Scripts />
-      </body>
-    </html>
+    <>
+      <Outlet />
+      <ScrollRestoration />
+      <Scripts />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add a head-level theme bootstrap script and switch the default favicon link to the existing SVG asset so the server markup matches what the browser expects
- rebuild the Pages server bundle to hydrate only the outlet container while preserving the body classes and reusing the theme bootstrap during streaming

## Testing
- pnpm lint *(manually interrupted after running for an extended period)*

------
https://chatgpt.com/codex/tasks/task_e_68d93aea94f88329a52b5c1c62db1828