### PR TITLE
Add API chat route alias

### DIFF
--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -1,0 +1,1 @@
+export { action } from './app.chat';


### PR DESCRIPTION
## Summary
- expose the existing chat action on the /api/chat route so the chat UI can call it

## Testing
- npm run lint *(fails: pre-existing lint violations throughout the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d95229d5a4832988905ab8576467e7